### PR TITLE
Rubocop small fixes

### DIFF
--- a/dist/rubocop.json
+++ b/dist/rubocop.json
@@ -74,6 +74,12 @@
       "type": "array",
       "uniqueItems": true,
       "items": { "$ref": "#/definitions/constant" }
+    },
+    "hashAlignmentEnforcedColonStyleEnum": {
+      "enum": ["key", "separator", "table"]
+    },
+    "hashAlignmentEnforcedHashRocketStyleEnum": {
+      "enum": ["key", "separator", "table"]
     }
   },
   "properties": {
@@ -886,9 +892,25 @@
         {
           "properties": {
             "EnforcedHashRocketStyle": {
-              "enum": ["key", "separator", "table"]
+              "anyOf": [
+                { "$ref": "#/definitions/hashAlignmentEnforcedHashRocketStyleEnum" },
+                {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": { "$ref": "#/definitions/hashAlignmentEnforcedHashRocketStyleEnum" }
+                }
+              ]
             },
-            "EnforcedColonStyle": { "enum": ["key", "separator", "table"] },
+            "EnforcedColonStyle": {
+              "anyOf": [
+                { "$ref": "#/definitions/hashAlignmentEnforcedColonStyleEnum" },
+                {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "items": { "$ref": "#/definitions/hashAlignmentEnforcedColonStyleEnum" }
+                }
+              ]
+            },
             "EnforcedLastArgumentHashStyle": {
               "enum": [
                 "always_inspect",

--- a/dist/rubocop.json
+++ b/dist/rubocop.json
@@ -2894,9 +2894,14 @@
                     "type": "string"
                   },
                   "Suggestions": {
-                    "type": "array",
-                    "uniqueItems": true,
-                    "items": { "type": "string" }
+                    "anyOf": [
+                      { "type": "string" },
+                      {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "items": { "type": "string" }
+                      }
+                    ]
                   },
                   "WholeWord": {
                     "type": "boolean"


### PR DESCRIPTION
RuboCop can handle this:

```yml
Naming/InclusiveLanguage:
    'foo':
      Suggestions: bar

Layout/HashAlignment:
  EnforcedHashRocketStyle:
    - key
    - table
```

First time writing json schema, let me know if this is done wrong. Tested locally and seems to work. Commit messages contain links to the code that shows where this is handled.

BTW, great work with this. Having any sort of autocomplete for this in the editor is pretty great :+1: 