### PR TITLE
Yfix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ return {
 
 ## Manual
 
-YFor YAML files, add this to the top of your file:
+For YAML files, add this to the top of your file:
 
 ```yml
 # yaml-language-server: $schema=<schema_url>


### PR DESCRIPTION
Although I fully support the Y in YAML, reading the README left me wondering why there is a Y. I could not find a good reason for it, therefore I humbly request to remove the leading Y.

ICANHAZ Merge?